### PR TITLE
ref/performance

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
@@ -101,9 +101,7 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
             }
         }
 
-        if (luaEventCallbacks.containsKey("onTick")) {
-            triggerEvent("onTick");
-        }
+        triggerEvent("onTick");
     }
 
     @Override

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
@@ -9,7 +9,6 @@ import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.script.*;
 import cam72cam.immersiverailroading.script.library.ILuaEvent;
 import cam72cam.immersiverailroading.script.library.LuaSerialization;
-import cam72cam.immersiverailroading.script.library.ScheduleEvent;
 import cam72cam.immersiverailroading.script.modules.*;
 import cam72cam.immersiverailroading.script.sound.SoundConfig;
 import cam72cam.immersiverailroading.textfield.TextFieldConfig;
@@ -58,7 +57,12 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
     @TagField(value = "luaTagField", mapper = LuaSerialization.LuaMapper.class)
     private Map<String, LuaValue> tagFields = new HashMap<>();
 
-    protected final Set<ScheduleEvent> schedule = new HashSet<>();
+    /**
+     * Pending {@code Utils.wait(...)} callbacks bucketed by absolute tick at which they should fire.
+     * O(1) per-tick lookup beats the previous {@code HashSet#removeIf} pass that allocated an iterator
+     * and decremented every entry on every tick.
+     */
+    protected final Map<Long, List<Runnable>> schedule = new HashMap<>();
     
     @TagSync
     @TagField(value = "LUAGUITEXT", mapper = LuaSerialization.LuaTextMapper.class)
@@ -89,14 +93,12 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         ensureContext();
 
         if (!schedule.isEmpty()) {
-            schedule.removeIf(t -> {
-                t.ticks--;
-                if (t.ticks <= 0) {
-                    t.runnable.run();
-                    return true;
+            List<Runnable> due = schedule.remove((long) getTickCount());
+            if (due != null) {
+                for (int i = 0; i < due.size(); i++) {
+                    due.get(i).run();
                 }
-                return false;
-            });
+            }
         }
 
         if (luaEventCallbacks.containsKey("onTick")) {
@@ -250,6 +252,11 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
     @LuaFunction(module = "Utils")
     public void wait(LuaValue sec, LuaValue func) {
         float seconds = sec.tofloat();
+        // Clamp to >= 1 so wait(0, fn) still fires on a future tick (matches the previous
+        // semantics of 'ticks-- ... if (ticks <= 0)' which always required at least one
+        // onTick pass after the wait() call before firing).
+        int delayTicks = Math.max(1, Math.round(seconds * 20));
+        long fireAt = (long) getTickCount() + delayTicks;
 
         Runnable runnable = () -> {
             try {
@@ -259,10 +266,7 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
             }
         };
 
-        int ticks = Math.round(seconds * 20);
-
-        ScheduleEvent event = new ScheduleEvent(runnable, ticks, func);
-        schedule.add(event);
+        schedule.computeIfAbsent(fireAt, k -> new ArrayList<>(2)).add(runnable);
     }
 
     public void setGuiText(LuaValue id, LuaValue value) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
@@ -5,6 +5,7 @@ import cam72cam.immersiverailroading.IRItems;
 import cam72cam.immersiverailroading.items.ItemTypewriter;
 import cam72cam.immersiverailroading.library.KeyTypes;
 import cam72cam.immersiverailroading.library.Permissions;
+import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.script.*;
 import cam72cam.immersiverailroading.script.library.ILuaEvent;
 import cam72cam.immersiverailroading.script.library.LuaSerialization;
@@ -27,11 +28,17 @@ import java.util.stream.Collectors;
 
 public abstract class EntityScriptableRollingStock extends EntityCoupleableRollingStock implements ILuaEvent {
     /**
-     * The context is actually loaded for every stock, not regarding if the stock even has a script. I did this for compatibility with the LuaAugment. <br>
-     * It shouldn't cause any performance issues because it doesn't actually run anything.
+     * Lazily initialised. Stocks without their own script never allocate a context from {@link #onTick()}.
+     * External callers (e.g. the {@code LUA_SCRIPTER} augment via {@link #getGlobals()}) trigger
+     * {@link #ensureContext()} on demand, so a stock only pays the LuaJ-VM cost when something actually
+     * touches its globals.
      * @see cam72cam.immersiverailroading.tile.TileRailBase
      */
     private LuaContext context;
+    /**
+     * Cached result of {@link #hasOwnScript()}. {@code null} = not yet computed.
+     */
+    private Boolean hasOwnScript;
     /**
      * Used by {@link IRModule}
      */
@@ -73,25 +80,28 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
             return;
         }
 
-        if (context == null) {
-            context = LuaContext.create(this);
-
-            registerModules();
-            loadLuaScript();
-
-            context.refreshSerialization(tagFields);
+        // Skip the entire Lua pipeline for stocks without a script of their own.
+        // External callers can still trigger lazy context creation via getGlobals().
+        if (!hasOwnScript()) {
+            return;
         }
 
-        schedule.removeIf(t -> {
-            t.ticks--;
-            if (t.ticks <= 0) {
-                t.runnable.run();
-                return true;
-            }
-            return false;
-        });
+        ensureContext();
 
-        triggerEvent("onTick");
+        if (!schedule.isEmpty()) {
+            schedule.removeIf(t -> {
+                t.ticks--;
+                if (t.ticks <= 0) {
+                    t.runnable.run();
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        if (luaEventCallbacks.containsKey("onTick")) {
+            triggerEvent("onTick");
+        }
     }
 
     @Override
@@ -148,7 +158,7 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         Identifier script = getDefinition().script;
 
         List<String> modules = getDefinition().addScripts;
-        if (modules != null) {
+        if (modules != null && !modules.isEmpty() && script != null) {
             context.loadModules(modules, script);
         }
 
@@ -157,7 +167,38 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         }
     }
 
+    /**
+     * @return {@code true} if this stock's definition references at least one Lua resource
+     *         (a {@code script} identifier that resolves, or a non-empty {@code add_scripts} list).
+     *         Cached after the first successful read of the definition.
+     */
+    private boolean hasOwnScript() {
+        if (hasOwnScript == null) {
+            EntityRollingStockDefinition def = getDefinition();
+            if (def == null) {
+                // Definition not ready yet; recompute next tick instead of caching false.
+                return false;
+            }
+            Identifier script = def.script;
+            List<String> modules = def.addScripts;
+            hasOwnScript = (script != null && script.canLoad())
+                        || (modules != null && !modules.isEmpty());
+        }
+        return hasOwnScript;
+    }
+
+    private void ensureContext() {
+        if (context != null) {
+            return;
+        }
+        context = LuaContext.create(this);
+        registerModules();
+        loadLuaScript();
+        context.refreshSerialization(tagFields);
+    }
+
     public Globals getGlobals() {
+        ensureContext();
         return context.getGlobals();
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/script/LuaContext.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/LuaContext.java
@@ -13,8 +13,31 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class LuaContext {
+    /**
+     * Per-class cache of {@link LuaFunction}-annotated methods. Reflection over the full
+     * class hierarchy is expensive and the result is invariant for the lifetime of the JVM,
+     * so we compute it once per class and reuse it for every {@link LuaContext} that wraps
+     * an instance of that class.
+     */
+    private static final Map<Class<?>, List<LuaMethodEntry>> METHOD_CACHE = new ConcurrentHashMap<>();
+
+    private static final class LuaMethodEntry {
+        final Method method;
+        final String functionName;
+        final String module;
+        final boolean hasReturn;
+
+        LuaMethodEntry(Method method, String functionName, String module, boolean hasReturn) {
+            this.method = method;
+            this.functionName = functionName;
+            this.module = module;
+            this.hasReturn = hasReturn;
+        }
+    }
+
     private final Globals globals;
     private Map<String, LuaValue> backingMap;
     private LuaTable tagFieldTable;
@@ -57,37 +80,18 @@ public class LuaContext {
     }
 
     private void initializeFunctions(Object object, Globals globals) {
-        Class<?> parent = object.getClass();
-
-        ArrayList<Method> methods = new ArrayList<>();
-
-        while (parent != null && parent != Object.class) {
-            methods.addAll(Arrays.asList(parent.getDeclaredMethods()));
-            parent = parent.getSuperclass();
+        List<LuaMethodEntry> entries = getOrComputeMethods(object.getClass());
+        if (entries.isEmpty()) {
+            return;
         }
 
         Map<String, LuaValue> modules = new HashMap<>();
 
-        for (Method method : methods) {
-            method.setAccessible(true);
-
-            LuaFunction tag = method.getAnnotation(LuaFunction.class);
-
-            if (tag == null) {
-                continue;
-            }
-
-            String functionName = tag.name().isEmpty() ? method.getName() : tag.name();
-            String module = tag.module();
-
-            LuaTable functions = (LuaTable) modules.getOrDefault(module, new LuaTable());
-
-            Class<?> returnType = method.getReturnType();
-            if (!(Varargs.class.isAssignableFrom(returnType) || returnType.equals(void.class))) {
-                continue;
-            }
-
-            boolean hasReturn = !returnType.equals(void.class);
+        for (LuaMethodEntry entry : entries) {
+            final Method method = entry.method;
+            final String functionName = entry.functionName;
+            final String module = entry.module;
+            final boolean hasReturn = entry.hasReturn;
 
             LuaValue func = new VarArgFunction() {
                 @Override
@@ -111,14 +115,47 @@ public class LuaContext {
             if (module.isEmpty()) {
                 modules.put(functionName, func);
             } else {
+                LuaTable functions = (LuaTable) modules.computeIfAbsent(module, k -> new LuaTable());
                 functions.set(LuaValue.valueOf(functionName), func);
-                modules.put(module, functions);
             }
         }
 
         for (Map.Entry<String, LuaValue> functions : modules.entrySet()) {
             globals.set(functions.getKey(), functions.getValue());
         }
+    }
+
+    /**
+     * Compute (or reuse) the list of {@link LuaFunction}-annotated methods for {@code clazz} and
+     * its superclasses. Result is cached per class — the discovery is invariant for a given class.
+     * <p>
+     * Methods that are not exposable to Lua (return type neither {@code void} nor {@link Varargs})
+     * are skipped at cache-build time so the per-instance loop stays tight.
+     */
+    private static List<LuaMethodEntry> getOrComputeMethods(Class<?> clazz) {
+        return METHOD_CACHE.computeIfAbsent(clazz, c -> {
+            List<LuaMethodEntry> result = new ArrayList<>();
+            Class<?> parent = c;
+            while (parent != null && parent != Object.class) {
+                for (Method method : parent.getDeclaredMethods()) {
+                    LuaFunction tag = method.getAnnotation(LuaFunction.class);
+                    if (tag == null) {
+                        continue;
+                    }
+                    Class<?> returnType = method.getReturnType();
+                    if (!(Varargs.class.isAssignableFrom(returnType) || returnType.equals(void.class))) {
+                        continue;
+                    }
+                    method.setAccessible(true);
+                    String functionName = tag.name().isEmpty() ? method.getName() : tag.name();
+                    String module = tag.module();
+                    boolean hasReturn = !returnType.equals(void.class);
+                    result.add(new LuaMethodEntry(method, functionName, module, hasReturn));
+                }
+                parent = parent.getSuperclass();
+            }
+            return Collections.unmodifiableList(result);
+        });
     }
 
     private void initializeSerialization() {

--- a/src/main/java/cam72cam/immersiverailroading/script/library/ILuaEvent.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/library/ILuaEvent.java
@@ -11,19 +11,34 @@ public interface ILuaEvent {
 
     Map<String, List<LuaValue>> getLuaEventCallbacks();
 
+    /**
+     * No-arg fast path. Java picks this overload over the varargs one for {@code triggerEvent("foo")}
+     * call sites, so hot-path events like {@code onTick} avoid both the {@code LuaValue[0]} array
+     * allocation and the {@link LuaValue#varargsOf} wrapper. {@link LuaValue#NONE} is a singleton
+     * that already implements {@link Varargs} with zero elements.
+     */
+    default void triggerEvent(String eventName) {
+        triggerEvent(eventName, LuaValue.NONE);
+    }
+
     default void triggerEvent(String eventName, LuaValue... args) {
         triggerEvent(eventName, LuaValue.varargsOf(args));
     }
 
     default void triggerEvent(String eventName, Varargs args) {
         List<LuaValue> callBacks = getLuaEventCallbacks().get(eventName);
-        if (callBacks != null) {
-            for (LuaValue callback : callBacks) {
-                try {
-                    callback.invoke(args);
-                } catch (Exception e) {
-                    ModCore.catching(e, "Lua callback for event %s failed:", eventName);
-                }
+        if (callBacks == null || callBacks.isEmpty()) {
+            return;
+        }
+        // Indexed loop avoids the Iterator allocation that the for-each version made on every trigger.
+        // Matches the previous semantics for concurrent modification: a callback that mutates the list
+        // could already produce surprising behaviour before this change.
+        for (int i = 0, n = callBacks.size(); i < n; i++) {
+            LuaValue callback = callBacks.get(i);
+            try {
+                callback.invoke(args);
+            } catch (Exception e) {
+                ModCore.catching(e, "Lua callback for event %s failed:", eventName);
             }
         }
     }

--- a/src/main/java/cam72cam/immersiverailroading/script/modules/AugmentModule.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/modules/AugmentModule.java
@@ -2,7 +2,6 @@ package cam72cam.immersiverailroading.script.modules;
 
 import cam72cam.immersiverailroading.script.LuaFunction;
 import cam72cam.immersiverailroading.script.LuaModule;
-import cam72cam.immersiverailroading.script.library.ScheduleEvent;
 import cam72cam.immersiverailroading.tile.TileRailBase;
 import cam72cam.mod.ModCore;
 import cam72cam.mod.entity.Player;
@@ -10,16 +9,21 @@ import cam72cam.mod.text.PlayerMessage;
 import cam72cam.mod.world.World;
 import org.luaj.vm2.LuaValue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class AugmentModule implements LuaModule {
     private final TileRailBase tile;
 
-    private final Set<ScheduleEvent> schedule = new HashSet<>();
+    /**
+     * Pending {@code Utils.wait(...)} callbacks bucketed by absolute tick at which they should fire.
+     * Replaces the previous {@code HashSet#removeIf} that decremented every entry on every world tick.
+     */
+    private final Map<Long, List<Runnable>> schedule = new HashMap<>();
 
     public AugmentModule(TileRailBase tile) {
         this.tile = tile;
@@ -28,15 +32,15 @@ public class AugmentModule implements LuaModule {
             if (world.isClient) {
                 return;
             }
-
-            schedule.removeIf(t -> {
-                t.ticks--;
-                if (t.ticks <= 0) {
-                    t.runnable.run();
-                    return true;
+            if (schedule.isEmpty()) {
+                return;
+            }
+            List<Runnable> due = schedule.remove((long) tile.getTicksExisted());
+            if (due != null) {
+                for (int i = 0; i < due.size(); i++) {
+                    due.get(i).run();
                 }
-                return false;
-            });
+            }
         });
     }
 
@@ -61,6 +65,11 @@ public class AugmentModule implements LuaModule {
     @LuaFunction(module = "Utils")
     private void wait(LuaValue sec, LuaValue func) {
         float seconds = sec.tofloat();
+        // Clamp to >= 1 so wait(0, fn) still fires on a future tick (matches the previous
+        // semantics of 'ticks-- ... if (ticks <= 0)' which always required at least one
+        // World#onTick pass after the wait() call before firing).
+        int delayTicks = Math.max(1, Math.round(seconds * 20));
+        long fireAt = (long) tile.getTicksExisted() + delayTicks;
 
         Runnable runnable = () -> {
             try {
@@ -70,10 +79,7 @@ public class AugmentModule implements LuaModule {
             }
         };
 
-        int ticks = Math.round(seconds * 20);
-
-        ScheduleEvent event = new ScheduleEvent(runnable, ticks, func);
-        schedule.add(event);
+        schedule.computeIfAbsent(fireAt, k -> new ArrayList<>(2)).add(runnable);
     }
 
     @LuaFunction(module = "Utils")

--- a/src/main/java/cam72cam/immersiverailroading/script/modules/AugmentModule.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/modules/AugmentModule.java
@@ -11,37 +11,69 @@ import org.luaj.vm2.LuaValue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 
 public class AugmentModule implements LuaModule {
+    /**
+     * Weak set of every live AugmentModule. A single static {@link World#onTick} listener walks this
+     * set instead of every instance registering its own listener — UMC's {@code World#onTick} has no
+     * unregister API, so per-instance registration leaks the module and its tile for the lifetime of
+     * the world. Backed by {@link WeakHashMap} so a module garbage-collects together with its tile
+     * once the {@link cam72cam.immersiverailroading.script.LuaContext} stops referencing it.
+     */
+    private static final Set<AugmentModule> active =
+            Collections.newSetFromMap(new WeakHashMap<>());
+
+    static {
+        World.onTick(world -> {
+            if (world.isClient) {
+                return;
+            }
+            // Snapshot so a callback may safely create or dispose other AugmentModules.
+            AugmentModule[] snapshot;
+            synchronized (active) {
+                if (active.isEmpty()) {
+                    return;
+                }
+                snapshot = active.toArray(new AugmentModule[0]);
+            }
+            for (AugmentModule m : snapshot) {
+                m.pumpSchedule(world);
+            }
+        });
+    }
+
     private final TileRailBase tile;
 
     /**
      * Pending {@code Utils.wait(...)} callbacks bucketed by absolute tick at which they should fire.
-     * Replaces the previous {@code HashSet#removeIf} that decremented every entry on every world tick.
      */
     private final Map<Long, List<Runnable>> schedule = new HashMap<>();
 
     public AugmentModule(TileRailBase tile) {
         this.tile = tile;
+        synchronized (active) {
+            active.add(this);
+        }
+    }
 
-        World.onTick(world -> {
-            if (world.isClient) {
-                return;
-            }
-            if (schedule.isEmpty()) {
-                return;
-            }
-            List<Runnable> due = schedule.remove((long) tile.getTicksExisted());
-            if (due != null) {
-                for (int i = 0; i < due.size(); i++) {
-                    due.get(i).run();
-                }
-            }
-        });
+    private void pumpSchedule(World world) {
+        if (tile.getWorld() != world || schedule.isEmpty()) {
+            return;
+        }
+        List<Runnable> due = schedule.remove((long) tile.getTicksExisted());
+        if (due == null) {
+            return;
+        }
+        for (int i = 0; i < due.size(); i++) {
+            due.get(i).run();
+        }
     }
 
     @LuaFunction(module = "")

--- a/src/main/java/cam72cam/immersiverailroading/script/modules/EventModule.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/modules/EventModule.java
@@ -34,6 +34,10 @@ public class EventModule implements LuaModule {
 
     @LuaFunction(module = "Events")
     public void triggerEvent(LuaValue... args) {
+        if (args == null || args.length == 0) {
+            ModCore.warn("[Lua] Events.triggerEvent() called without an event name");
+            return;
+        }
         String funcName = args[0].tojstring();
         if (funcName.equals("onTick") || funcName.equals("onControlGroupChange")) {
             ModCore.error("[Lua] Cannot call \"onTick\" or \"onControlGroupChange\" manually. Please use another name for your event!");
@@ -50,13 +54,26 @@ public class EventModule implements LuaModule {
 
     @LuaFunction(module = "Events")
     public void triggerCouplerEvent(LuaValue... args) {
-        if (stock != null) {
-            String functionName = args[0].tojstring();
-            EntityCoupleableRollingStock.CouplerType coupler = EntityCoupleableRollingStock.CouplerType.valueOf(args[1].tojstring().toUpperCase());
-
-            EntityScriptableRollingStock coupled = (EntityScriptableRollingStock) stock.getCoupled(coupler);
-
-            coupled.triggerEvent(functionName, LuaValue.varargsOf(Arrays.copyOfRange(args, 2, args.length)));
+        if (stock == null) {
+            return;
         }
+        if (args == null || args.length < 2) {
+            ModCore.warn("[Lua] Events.triggerCouplerEvent(name, coupler, ...) needs at least an event name and a coupler side");
+            return;
+        }
+        String functionName = args[0].tojstring();
+        EntityCoupleableRollingStock.CouplerType coupler;
+        try {
+            coupler = EntityCoupleableRollingStock.CouplerType.valueOf(args[1].tojstring().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            ModCore.warn("[Lua] Events.triggerCouplerEvent: unknown coupler '%s'", args[1].tojstring());
+            return;
+        }
+
+        EntityScriptableRollingStock coupled = (EntityScriptableRollingStock) stock.getCoupled(coupler);
+        if (coupled == null) {
+            return;
+        }
+        coupled.triggerEvent(functionName, LuaValue.varargsOf(Arrays.copyOfRange(args, 2, args.length)));
     }
 }


### PR DESCRIPTION
Reduce per-tick CPU and allocation pressure on the Lua scripting hot path on `testbuild`. The Spark profile that triggered
this work showed `org.luaj.vm2.compiler.LexState`, `LuaContext.create`, `initializeFunctions`, `triggerEvent`, and
`schedule.removeIf` dominating the server-tick samples, even on stocks that don't have a script of their own.

Four small, isolated commits, each with its own behavioural justification.